### PR TITLE
Fix null pointer bug in AbilitiesMixin.java for v1.19 branch

### DIFF
--- a/common/src/main/java/de/maxhenkel/betterrespawn/mixin/AbilitiesMixin.java
+++ b/common/src/main/java/de/maxhenkel/betterrespawn/mixin/AbilitiesMixin.java
@@ -29,8 +29,10 @@ public class AbilitiesMixin implements RespawnAbilities {
 
         CompoundTag betterRespawn = new CompoundTag();
 
-        betterRespawn.putString("respawn_dimension", respawnDimension.location().toString());
-
+        if (respawnDimension != null) {
+            betterRespawn.putString("respawn_dimension", respawnDimension.location().toString());
+        }
+        
         if (respawnPos != null) {
             CompoundTag pos = new CompoundTag();
             pos.putInt("x", respawnPos.getX());


### PR DESCRIPTION
I'm using this mod in 1.19 Minecraft Game. I found that this bug is fixed in the later version, so I tried to also fix it in v1.19.